### PR TITLE
Include Integrated Graphics in docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,3 +26,4 @@ COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 CMD ["bash"]
 
+WORKDIR /project_billee_2025

--- a/docs/onboarding/3 - 3rd Party Packages And ROS.md
+++ b/docs/onboarding/3 - 3rd Party Packages And ROS.md
@@ -1,0 +1,8 @@
+# 3 - Integrating 3rd Party Packages With ROS
+
+## Using rosdep
+
+
+`rosdep` is a way of installing 3rd party pacakges. You can access the [list of third party rosdep packages for python here](https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml)
+
+

--- a/launch_container.bash
+++ b/launch_container.bash
@@ -1,4 +1,4 @@
 xhost +
 
-sudo docker run -it --network=host --ipc=host -v $PWD/:/project_billee_2025 -v /tmp/.X11-unix:/tmp/.X11-unix:rw --env=DISPLAY --device=/dev/input:/dev/input --device-cgroup-rule='c 13:* rmw' billee
+sudo docker run -it --network=host --ipc=host -v $PWD/:/project_billee_2025 -v /tmp/.X11-unix:/tmp/.X11-unix:rw --env=DISPLAY --device=/dev/input:/dev/input --device-cgroup-rule='c 13:* rmw' --device=/dev/dri/renderD128:/dev/dri/renderD128 --device-cgroup-rule='c 13:* rmw' billee
 

--- a/launch_container.bash
+++ b/launch_container.bash
@@ -1,4 +1,9 @@
 xhost +
 
-sudo docker run -it --network=host --ipc=host -v $PWD/:/project_billee_2025 -v /tmp/.X11-unix:/tmp/.X11-unix:rw --env=DISPLAY --device=/dev/input:/dev/input --device-cgroup-rule='c 13:* rmw' --device=/dev/dri/renderD128:/dev/dri/renderD128 --device-cgroup-rule='c 13:* rmw' billee
+sudo docker run -it --network=host --ipc=host \
+	-v $PWD/:/project_billee_2025 \
+	-v /tmp/.X11-unix:/tmp/.X11-unix:rw --env=DISPLAY \
+	--device=/dev/input:/dev/input --device-cgroup-rule='c 13:* rmw' \
+	--device=/dev/dri/renderD128:/dev/dri/renderD128 --device-cgroup-rule='c 13:* rmw'\
+	billee
 


### PR DESCRIPTION
Resolves the issues with low frame rates in gazebo. Also cleaned up the launch_container file as well as made separate launch file for jetson only to utilize gpus.